### PR TITLE
feat: Implement offline message caching

### DIFF
--- a/components/HaLowManager/include/HaLowMeshManager.h
+++ b/components/HaLowManager/include/HaLowMeshManager.h
@@ -12,6 +12,15 @@ struct MeshNodeInfo {
     // Add other relevant info like RSSI, etc.
 };
 
+// Structure to hold a cached message
+struct CachedMessage {
+    std::vector<uint8_t> data;
+    uint16_t port;
+    std::string destIp; // Empty for multicast
+    bool isMulticast;
+};
+
+
 class HaLowMeshManager {
 public:
     // Singleton access method
@@ -33,13 +42,16 @@ public:
     // Send a UDP packet to a specific unicast address
     bool sendUdpUnicast(const std::string& destIp, const uint8_t* data, size_t size, uint16_t port);
 
-    // TODO: Add methods for TCP communication
-    // bool connectTcp(const std::string& destIp, uint16_t port);
-    // bool sendTcp(const uint8_t* data, size_t size);
-    // void disconnectTcp();
-
     // Get a list of discovered mesh nodes
     std::vector<MeshNodeInfo> getMeshNodes();
+
+    // Connection status management
+    void setConnectionStatus(bool status);
+    bool get_connection_status() const;
+
+    // Send any messages that were cached while offline
+    void sendCachedMessages();
+
 
 private:
     // Private constructor for singleton
@@ -48,6 +60,11 @@ private:
 
     // Flag to track initialization status
     bool isInitialized;
+    // Flag to track mesh connection status
+    bool isConnected;
+
+    // Cache for messages to be sent when connection is restored
+    std::vector<CachedMessage> messageCache;
 };
 
 #endif // HALOW_MESH_MANAGER_H


### PR DESCRIPTION
This commit introduces an offline caching mechanism for messages. When the device is disconnected from the HaLow mesh network, outgoing UDP packets (both unicast and multicast) are cached in memory instead of being dropped.

- HaLowMeshManager is enhanced with a connection status flag (`isConnected`) and a message cache (`messageCache`).
- `sendUdpMulticast` and `sendUdpUnicast` now check the connection status. If offline, they queue the message; if online, they send it directly.
- A new function `sendCachedMessages` is added to transmit all stored messages upon reconnection.
- The UI task is updated to provide a visual indication of the connection status (Online/Offline) on the main screen.
- For testing and demonstration, the 'BACK' button on the main screen now toggles the connection status, triggering the sending of cached messages upon reconnection.